### PR TITLE
Fix shader code for OpenGL ES

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -163,7 +163,7 @@ Shader = love.graphics.newShader [[
     #ifdef PIXEL
         vec4 effect(vec4 color, Image tex, vec2 texcoord, vec2 pixcoord)
         {
-            vec4 texcolor = Texel(tex, vec2(texcoord.x, 1-texcoord.y));
+            vec4 texcolor = Texel(tex, vec2(texcoord.x, 1.0-texcoord.y));
             if (texcolor.a == 0.0) { discard; }
             return vec4(texcolor)*color*vertexColor;
         }


### PR DESCRIPTION
Running this on Android errors with
```
Error

Error validating pixel shader code:
Line 18: ERROR: '-' :  wrong operand types: no operation '-' exists that takes a left-hand operand of type ' const int' and a right operand of type ' temp mediump float' (or there is no acceptable conversion)
Line 18: ERROR: '' : missing #endif 
Line 18: ERROR: '' : compilation terminated 
ERROR: 3 compilation errors.  No code generated.


Traceback

[love "callbacks.lua"]:228: in function 'handler'
[C]: in function 'newShader'
main.lua:171: in main chunk
[C]: in function 'require'
[C]: in function 'xpcall'
[C]: in function 'xpcall'
```
It's because OpenGL ES requires number types to be explicitly cast and won't allow operators between int and float. See https://github.com/love2d/love-android/wiki/Shaders-in-Android

Simply changing the number to a float, it now runs perfectly on Android.